### PR TITLE
requests and error message

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "reactSnippets.settings.prettierEnabled": true,
+    "prettier.bracketSameLine": true,
+    "prettier.configPath": "frontend/src/.prettierrc",
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnPaste": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,3 +5,4 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnPaste": true
 }
+

--- a/frontend/src/containers/SignIn/SignIn.css
+++ b/frontend/src/containers/SignIn/SignIn.css
@@ -15,3 +15,8 @@
   display: flex;
   width: 300px;
 }
+
+.error {
+  color: red;
+  font-size: 16px;
+}

--- a/frontend/src/containers/SignUp/SignUp.css
+++ b/frontend/src/containers/SignUp/SignUp.css
@@ -15,3 +15,8 @@
   display: flex;
   width: 300px;
 }
+
+.errpr {
+  color: red;
+  font-size: 16px;
+}

--- a/frontend/src/containers/SignUp/SignUp.tsx
+++ b/frontend/src/containers/SignUp/SignUp.tsx
@@ -1,16 +1,24 @@
 import "./SignUp.css";
 
-import { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Stack, TextField } from "@mui/material";
 import { LoadingButton } from "@mui/lab";
+
+import axios from "axios";
 
 export default function SignUp() {
   const [email, setEmail] = useState<string>("");
   const [username, setUsername] = useState<string>("");
   const [password, setPassword] = useState<string>("");
   const [passwordConfirm, setPasswordConfirm] = useState<string>("");
+  const [error, setError] = useState<string>("");
+
   const navigate = useNavigate();
+
+  useEffect(() => {
+    setError("");
+  }, [email, username, password, passwordConfirm]);
 
   const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setEmail(event.target.value);
@@ -21,22 +29,77 @@ export default function SignUp() {
   const handlePasswordChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setPassword(event.target.value);
   };
-  const handlePasswordConfirmChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handlePasswordConfirmChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
     setPasswordConfirm(event.target.value);
   };
 
   const handleCancel = async () => {
     navigate(`/login`);
   };
-  const handleSignUp = async () => {
-    //Todo: Implement SignUp
+  const handleSignUp = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    setEmail(email.trim());
+    setUsername(username.trim());
+    setPassword(password.trim());
+    setPasswordConfirm(passwordConfirm.trim());
+
+    if (
+      email === "" ||
+      username === "" ||
+      password === "" ||
+      passwordConfirm === ""
+    ) {
+      alert("Please fill in all fields");
+      return;
+    }
+
+    if (password !== passwordConfirm) {
+      alert("Passwords do not match");
+      return;
+    }
+
+    try {
+      //Todo: fix url
+      const response = await axios.post(
+        "/api/users/signup",
+        JSON.stringify({
+          email: email,
+          username: username,
+          password: password,
+        }),
+        {
+          headers: {
+            "Content-Type": "application/json",
+            withCredentials: true,
+          },
+        }
+      );
+      //Todo: token
+      const token = response.data.token;
+
+      if (response.status === 200) {
+        navigate(`/login`);
+      }
+    } catch (error: any) {
+      if (!error.response) {
+        setError("Error connecting to server");
+      } else if (error.response.status === 409) {
+        setError("Email already exists");
+      } else {
+        setError("Error signing up");
+      }
+    }
   };
 
   return (
     <div className="SignUp">
       <h2>NotiManager</h2>
-      <form>
+      <form onSubmit={handleSignUp}>
         <Stack spacing={2}>
+          {error && <div className="error">{error}</div>}
           <TextField
             className="email"
             name="email"
@@ -73,19 +136,16 @@ export default function SignUp() {
           <LoadingButton
             fullWidth
             size="large"
-            type="submit"
             variant="contained"
             onClick={() => handleCancel()}
           >
             Cancel
           </LoadingButton>
           <LoadingButton
-
             fullWidth
             size="large"
             type="submit"
             variant="contained"
-            onClick={() => handleSignUp()}
           >
             SignUp
           </LoadingButton>
@@ -93,5 +153,4 @@ export default function SignUp() {
       </form>
     </div>
   );
-
 }


### PR DESCRIPTION
### Summary
**구현한 내용**
_1. SignIn.css, SignUp.css_
- Error Message 폰트크기 & 폰트색상

_2. SignIn.tsx_
- 로그인 버튼 onclick -> Form submit으로 변경
- axios 사용해서 request 보내기
- Error Message 구현 (입력이 비어있을 시, response가 401일시 등등)

_3. SignUp.tsx_
- SignIn과 동일

**추후 할일 (Todo)**
1. url 백엔드와 싱크 시키기
2. 토큰
3. 로그인 성공 시 userState 변경하기 (Home에서 데이터 보여주기 위함)

- (추가) way around? -> 백엔드, 토큰 등이 구현이 덜되었을 때 Home으로 갈 수 있는 방법도 필요할 듯

### CheckList 
- [x] Assignee
- [x] Reviewer
- [x] Labels
- [ ] Local Test Pass
- [ ] Test Code
- [x] (Front) Screenshot


### Reference
![image](https://user-images.githubusercontent.com/112914763/201021126-bd38bc0b-e50e-49b0-9db0-c10331f42a54.png)
![image](https://user-images.githubusercontent.com/112914763/201021396-0a0396d9-897e-45f7-935f-60ccb757a1b5.png)



### Notion Task Link


