### PR TITLE
message.ts의 test 코드

### DIFF
--- a/frontend/src/store/slices/message.test.ts
+++ b/frontend/src/store/slices/message.test.ts
@@ -1,0 +1,95 @@
+import {
+  AnyAction,
+  configureStore,
+  EnhancedStore,
+  ThunkMiddleware,
+} from "@reduxjs/toolkit";
+import axios from "axios";
+
+import { MessageType } from "../../types";
+import reducer, {
+  fetchMessage,
+  fetchMessages,
+  createMessage,
+  fetchMessagesByProjectId,
+} from "./message";
+
+describe("message reducer", () => {
+  let store: EnhancedStore<
+    {
+      message: { messages: MessageType[]; selectedMessage: MessageType | null };
+    },
+    AnyAction,
+    [
+      ThunkMiddleware<
+        {
+          message: {
+            messages: MessageType[];
+            selectedMessage: MessageType | null;
+          };
+        },
+        AnyAction,
+        undefined
+      >
+    ]
+  >;
+
+  const fakeMessages: MessageType[] = [
+    { id: 1, project: "1", content: "content1" },
+    { id: 2, project: "2", content: "content2" },
+    { id: 3, project: "3", content: "content3" },
+  ];
+
+  beforeAll(() => {
+    store = configureStore({ reducer: { message: reducer } });
+  });
+
+  it("should handle initial state", () => {
+    expect(reducer(undefined, { type: "unknown" })).toEqual({
+      messages: [],
+      selectedMessage: null,
+    });
+  });
+
+  it("should handle fetch messages", async () => {
+    jest.spyOn(axios, "get").mockImplementation((url: string) => {
+      return Promise.resolve({
+        data: fakeMessages,
+      });
+    });
+    await store.dispatch(fetchMessages());
+    expect(store.getState().message.messages).toEqual(fakeMessages);
+  });
+
+  it("should handle fetch message", async () => {
+    jest.spyOn(axios, "get").mockImplementation((url: string) => {
+      return Promise.resolve({
+        data: fakeMessages[0],
+      });
+    });
+    await store.dispatch(fetchMessage(1));
+    expect(store.getState().message.selectedMessage).toEqual(fakeMessages[0]);
+  });
+
+  it("should handle create message", async () => {
+    jest.spyOn(axios, "post").mockResolvedValue({ data: fakeMessages[0] });
+
+    await store.dispatch(
+      createMessage({
+        project: 1,
+        content: "test content",
+      })
+    );
+    expect(store.getState().message.selectedMessage).toEqual(fakeMessages[0]);
+  });
+
+  it("should handle fetch messages by project id", async () => {
+    jest.spyOn(axios, "get").mockImplementation((url: string) => {
+      return Promise.resolve({
+        data: [fakeMessages[0]],
+      });
+    });
+    await store.dispatch(fetchMessagesByProjectId(1));
+    expect(store.getState().message.messages).toEqual([fakeMessages[0]]);
+  });
+});

--- a/frontend/src/store/slices/message.ts
+++ b/frontend/src/store/slices/message.ts
@@ -15,7 +15,9 @@ export const fetchMessages = createAsyncThunk(
 export const fetchMessagesByProjectId = createAsyncThunk(
   "message/fetchMessages",
   async (projectId: number) => {
-    const response = await axios.get<MessageType[]>(`/api/message?projectId=${projectId}`);
+    const response = await axios.get<MessageType[]>(
+      `/api/message?projectId=${projectId}`
+    );
     return response.data;
   }
 );
@@ -29,17 +31,18 @@ export const fetchMessage = createAsyncThunk(
 );
 
 export const createMessage = createAsyncThunk(
-    "message/createMessage",
-    async (message: {project: number, content: string}) => {
-        const response = await axios.post<MessageType>("/api/message/", message);
-        return response.data;
-    }
+  "message/createMessage",
+  async (message: { project: number; content: string }) => {
+    const response = await axios.post<MessageType>("/api/message/", message);
+    return response.data;
+  }
 );
-
 
 const initialState: {
   messages: MessageType[];
+  selectedMessage: MessageType | null;
 } = {
+  selectedMessage: null,
   messages: [],
 };
 
@@ -50,6 +53,9 @@ export const MessageSlice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(fetchMessages.fulfilled, (state, action) => {
       state.messages = action.payload;
+    });
+    builder.addCase(fetchMessage.fulfilled, (state, action) => {
+      state.selectedMessage = action.payload;
     });
   },
 });


### PR DESCRIPTION
### Summary
store/slices/message.ts에 대한 테스트 코드를 작성했습니다.
![2022-11-12 20_11_27-message test ts - swppfall2022-team15 - Visual Studio Code](https://user-images.githubusercontent.com/55076957/201471404-4892972f-e5b4-454a-960d-e4f28d271708.png)



### CheckList 
- [ ] Assignee
- [ ] Reviewer
- [ ] Labels
- [ ] Local Test Pass
- [ ] Test Code
- [ ] (Front) Screenshot


### Reference



### Notion Task Link


