### PR TITLE
url 관련 파일을 별도로 뺌

### DIFF
--- a/backend/core/api_urls.py
+++ b/backend/core/api_urls.py
@@ -1,0 +1,28 @@
+from django.urls import path
+from rest_framework.authtoken.views import obtain_auth_token
+from rest_framework.routers import DefaultRouter
+
+from account.views import SignUpView, UserView
+from nmessages.views import NMessageViewSet
+from notifications.views import NotificationViewSet
+from project.views import ProjectViewSet
+from targetusers.views import TargetUserViewSet
+
+urlpatterns = [
+    path('api/signin/', obtain_auth_token, name='signin'),
+    path('api/signup/', SignUpView.as_view(), name='signup'),
+    path('api/user/', UserView.as_view(), name='user'),
+]
+
+# ViewSet
+router = DefaultRouter()
+# project app
+router.register(r'project', ProjectViewSet, basename='project')
+# target user app
+router.register(r'targetuser', TargetUserViewSet, basename='targetuser')
+# message app
+router.register(r'message', NMessageViewSet, basename='nmessage')
+# notification app
+router.register(r'notification', NotificationViewSet, basename='notification')
+
+urlpatterns += router.urls

--- a/backend/noti_manager/urls.py
+++ b/backend/noti_manager/urls.py
@@ -15,18 +15,8 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
-from rest_framework.authtoken.views import obtain_auth_token
-
-from account.views import SignUpView, UserView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('api/signin/', obtain_auth_token, name='signin'),
-    path('api/signup/', SignUpView.as_view(), name='signup'),
-    path('api/user/', UserView.as_view(), name='user'),
-
-    path('api/project/', include('project.urls')),
-    path('api/notification/', include('notifications.urls')),
-    path('api/message/', include('nmessages.urls')),
-    path('api/targetuser/', include('targetusers.urls')),
+    path('api/', include('core.api_urls')),
 ]


### PR DESCRIPTION
### Summary
- 하나의 앱에 여러개의 뷰셋이 있는 경우, 현재의 구조로는 url path 를 유연성있게 추가하기가 어려워 이를 개선했습니다.
- api spec (endpoint) 의 변경은 없습니다.

### 문제점
- 반드시 settings.urls.py 에서, app 의 이름을 prefix 로 붙여준 후, 각 앱의 urls.py 를 include 해주고 있습니다.
- 그에 따라, url 에서 앱의 이름이 상위 path 에 포함되지 않아야 하는 경우를 수용할 수 없습니다.
### 개선책
- core.urls 를 만들고, 각 뷰셋 클래스를 urls 에서 직접 붙일 수 있도록 변경하였습니다.

### CheckList 
- [x] Assignee
- [x] Reviewer
- [x] Labels
- [ ] Local Test Pass
- [ ] Test Code
- [ ] (Front) Screenshot


### Reference



### Notion Task Link


